### PR TITLE
Correct some weirdness

### DIFF
--- a/docs/csharp/programming-guide/main-and-command-args/index.md
+++ b/docs/csharp/programming-guide/main-and-command-args/index.md
@@ -30,8 +30,8 @@ ms.locfileid: "82200121"
 ## <a name="overview"></a>개요
 
 - `Main` 메서드는 실행 가능한 프로그램의 진입점으로, 프로그램의 제어가 시작되고 끝나는 위치합니다.
-- `Main`은 클래스 또는 구조체 내부에 선언됩니다 `Main`은 [정적](../../language-reference/keywords/static.md)이어야 하며 [공용](../../language-reference/keywords/public.md)일 필요가 없습니다. (앞의 예제에서는 기본 액세스 권한 [개인](../../language-reference/keywords/private.md)을 받습니다.) 바깥쪽 클래스 또는 구조체는 정적일 필요가 없습니다.
-- `Main`에는 `void` 또는 `int`를 가지고 있거나 C# 7.1로 시작하거나 `Task` 또는 `Task<int>` 반환 형식을 가질 수 있습니다.
+- `Main`은 클래스 또는 구조체 내부에 선언됩니다 `Main`은 [정적](../../language-reference/keywords/static.md)이어야 하며 [공용](../../language-reference/keywords/public.md)일 필요가 없습니다. (앞의 예제에서는 기본 액세스 한정자인 [private](../../language-reference/keywords/private.md)으로 지정됩니다.) `Main`을 포함하는 클래스 또는 구조체는 정적일 필요가 없습니다.
+- `Main`은 `void` 또는 `int`를 반환 형식으로 가질 수 있으며 C# 7.1 부터는 `Task` 또는 `Task<int>` 반환 형식을 가질 수 있습니다.
 - `Main`에서 `Task` 또는 `Task<int>`을 반환하는 경우에만 `Main` 선언에 [`async`](../../language-reference/keywords/async.md) 한정자가 포함될 수 있습니다. 이는 구체적으로 `async void Main` 메서드를 제외합니다.
 - `Main` 메서드는 명령줄 인수를 포함하는 `string[]` 매개 변수 사용 여부에 관계 없이 선언될 수 있습니다. Visual Studio를 사용하여 Windows 애플리케이션을 만드는 경우 매개 변수를 수동으로 추가하거나 <xref:System.Environment.GetCommandLineArgs> 메서드를 사용하여 [명령줄 인수](command-line-arguments.md)를 가져올 수 있습니다. 매개 변수는 0부터 시작하는 명령줄 인수로 읽힙니다. C 및 C++와 달리, 프로그램의 이름이 `args` 배열의 첫 번째 명령줄 인수로 처리되지 않지만, <xref:System.Environment.GetCommandLineArgs> 메서드의 첫 번째 요소입니다.
 

--- a/docs/csharp/programming-guide/main-and-command-args/index.md
+++ b/docs/csharp/programming-guide/main-and-command-args/index.md
@@ -30,7 +30,7 @@ ms.locfileid: "82200121"
 ## <a name="overview"></a>개요
 
 - `Main` 메서드는 실행 가능한 프로그램의 진입점으로, 프로그램의 제어가 시작되고 끝나는 위치합니다.
-- `Main`은 클래스 또는 구조체 내부에 선언됩니다 `Main`은 [정적](../../language-reference/keywords/static.md)이어야 하며 [공용](../../language-reference/keywords/public.md)일 필요가 없습니다. (앞의 예제에서는 기본 액세스 한정자인 [private](../../language-reference/keywords/private.md)으로 지정됩니다.) `Main`을 포함하는 클래스 또는 구조체는 정적일 필요가 없습니다.
+- `Main`은 클래스 또는 구조체 내부에 선언됩니다 `Main`은 [static](../../language-reference/keywords/static.md)이어야 하며 [public](../../language-reference/keywords/public.md)일 필요가 없습니다. (앞의 예제에서는 기본 액세스 한정자인 [private](../../language-reference/keywords/private.md)으로 지정됩니다.) `Main`을 포함하는 클래스 또는 구조체는 정적일 필요가 없습니다.
 - `Main`은 `void` 또는 `int`를 반환 형식으로 가질 수 있으며 C# 7.1 부터는 `Task` 또는 `Task<int>` 반환 형식을 가질 수 있습니다.
 - `Main`에서 `Task` 또는 `Task<int>`을 반환하는 경우에만 `Main` 선언에 [`async`](../../language-reference/keywords/async.md) 한정자가 포함될 수 있습니다. 이는 구체적으로 `async void Main` 메서드를 제외합니다.
 - `Main` 메서드는 명령줄 인수를 포함하는 `string[]` 매개 변수 사용 여부에 관계 없이 선언될 수 있습니다. Visual Studio를 사용하여 Windows 애플리케이션을 만드는 경우 매개 변수를 수동으로 추가하거나 <xref:System.Environment.GetCommandLineArgs> 메서드를 사용하여 [명령줄 인수](command-line-arguments.md)를 가져올 수 있습니다. 매개 변수는 0부터 시작하는 명령줄 인수로 읽힙니다. C 및 C++와 달리, 프로그램의 이름이 `args` 배열의 첫 번째 명령줄 인수로 처리되지 않지만, <xref:System.Environment.GetCommandLineArgs> 메서드의 첫 번째 요소입니다.
@@ -48,7 +48,7 @@ public static async Task Main(string[] args) { }
 public static async Task<int> Main(string[] args) { }
 ```
 
-앞의 예에서는 모두 공용 접근자 한정자를 사용합니다. 일반적으로 그렇게 하지만 필수는 아닙니다.
+앞의 예에서는 모두 `public` 액세스 한정자를 사용합니다. 일반적으로 그렇게 하지만 필수는 아닙니다.
 
 `async` 및 `Task`, `Task<int>` 반환 형식을 추가하면 콘솔 애플리케이션을 시작해야 하고 비동기 작업을 `Main`에서 `await`해야 하는 경우에 프로그램 코드가 간소화됩니다.
 


### PR DESCRIPTION
Hello, I've found some weird expressions to read:

```
The enclosing class or struct is not required to be static.
```
`The enclosing` should be `Main을 포함하는` rather than `바깥쪽`, and its more clear to read.

```
Main can either have a void, int, or, starting with C# 7.1, Task, or Task<int> return type.
```
This expression is translated literally, however, the translation can give readers some confusion. 

I think these should be revised, so it will be grateful to check this patch!

Thank you!
